### PR TITLE
Fix wrong orange cloud display

### DIFF
--- a/actions/zone.php
+++ b/actions/zone.php
@@ -106,7 +106,7 @@ foreach ($dnsresult as $record) {
 		} else {
 			$proxiable = '<img src="images/cloud_off.png" height="30">';
 		}
-		if (isset($_GET['enable']) && $record->id == $_GET['enable']) {
+		if (isset($_GET['enable']) && $record->id === $_GET['enable']) {
 			$proxiable = '<a href="?action=zone&domain=' . $zone_name . '&disable=' . $record->id . '&page=' . $_GET['page'] . '&amp;zoneid=' . $zoneID . '"><img src="images/cloud_on.png" height="19"></a>';
 		} elseif (isset($_GET['disable']) && $record->id == $_GET['disable']) {
 			$proxiable = '<a href="?action=zone&domain=' . $zone_name . '&enable=' . $record->id . '&page=' . $_GET['page'] . '&amp;zoneid=' . $zoneID . '"><img src="images/cloud_off.png" height="30"></a>';


### PR DESCRIPTION
A non-proxied domain may wrongly display a orange cloud due to:

Line 58 set $_GET['enable'] = 1;

Although Line 100-108 set the $proxiable to cloud_off,
Line 109 if will be true because

 * $_GET['enable'] is int(1) so isset true
 * **AND $record->id string(1abcedf) equal (although its not identical) to int(1)**

You need to fix it by require identical string.